### PR TITLE
use unmerged upstream log location patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "nodemailer": "~1.2.1",
     "ws": "~0.4.32",
     "nodejs-websocket": "~1.0.0",
-    "tqtopicmap": "KnowledgeGarden/TQTopicMap",
+    "tqtopicmap": "KnowledgeGarden/TQTopicMap#feature/logfile-path",
     "morgan": "~1.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
this should not be merged until a resolution to #6 found, as it pins a reference to an upstream branch that may not be merged