### PR TITLE
pass resolved path to bootstrap

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ Environment.start(function(err, env) {
 	var bootstrap = new Bs(Environment.getTopicMapEnvironment()),
 
 		//models/lib/tqtopicmap/node_modules
-		bdir = "/../../../../bootstrap";
+		bdir = path.resolve(__dirname, './bootstrap');
 	console.log("SERVER B");
 	//now that environment is up, run bootstrap to see
 	// if there is new information to add to the index


### PR DESCRIPTION
Evaluating a relative path in the context of another file is fishy, since we don't know where this file is located.

This is particularly important since a dev working on this project will likely run [`npm link /path/to/tqtopicmap`](https://docs.npmjs.com/cli/link) while hacking so that changes made to the dependent module can be managed using that module's version control.

Note that `npm link` will likely epic fail on ancient windows, but should work fine in modern versions as long as ntfs symbolic links are available. The generic symlink call is used in posix compliant oses.
